### PR TITLE
Make ColorMapper optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <repositories>
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+    </repository>
+  </repositories>
   <!-- Dependencies -->
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
       <artifactId>jansi</artifactId>
       <version>1.11</version>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   <!-- Build behavior -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <repositories>
-    <repository>
-      <id>spigot-repo</id>
-      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
-    </repository>
-  </repositories>
   <!-- Dependencies -->
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.github.mywarp</groupId>
+  <groupId>info.ronjenkins</groupId>
   <artifactId>slf4bukkit</artifactId>
   <version>0.1.5-SNAPSHOT</version>
   <name>SLF4Bukkit</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>info.ronjenkins</groupId>
+  <groupId>io.github.mywarp</groupId>
   <artifactId>slf4bukkit</artifactId>
   <version>0.1.5-SNAPSHOT</version>
   <name>SLF4Bukkit</name>

--- a/src/main/java/info/ronjenkins/slf4bukkit/AnsiColorMapper.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/AnsiColorMapper.java
@@ -25,17 +25,27 @@ import org.fusesource.jansi.Ansi.Attribute;
 import java.util.Map;
 
 /**
- * Maps {@link ChatColor} values to their JAnsi equivalents.
+ * Maps {@link ChatColor} values to their Jansi equivalents.
  *
- * <p>This class might not always be instantiable as jansi might not be present at runtime.</p>
+ * <p>This class might not always be instantiable as Jansi might not be present at runtime.</p>
  *
  * @author Ronald Jack Jenkins Jr.
  */
 final class AnsiColorMapper implements ColorMapper {
 
+  /**
+   * Creates a new instance.
+   *
+   * <p>This class relies on Jansi. If this dependency is not present at runtime, it cannot be initialized as the JVM
+   * raises a {@code Throwable} due to missing dependencies.</p>
+   *
+   * <p>In this case callers of this constructor should fall back to an alternative {@code ColorMapper}
+   * implementation.</p>
+   *
+   * @throws Throwable if Jansi is not present at runtime
+   */
   AnsiColorMapper() throws Throwable {
-    // Calling this constructor could result in a Throwable because JAnsi, which is required to execute code
-    // in this class, might not be present at runtime, thus expected classes are not found.
+    //see javadoc
   }
 
   // @formatter:off

--- a/src/main/java/info/ronjenkins/slf4bukkit/AnsiColorMapper.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/AnsiColorMapper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 Ronald Jack Jenkins Jr.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package info.ronjenkins.slf4bukkit;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.bukkit.ChatColor;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Attribute;
+
+import java.util.Map;
+
+/**
+ * Maps {@link ChatColor} values to their JAnsi equivalents.
+ *
+ * <p>This class might not always be instantiable as jansi might not be present at runtime.</p>
+ *
+ * @author Ronald Jack Jenkins Jr.
+ */
+final class AnsiColorMapper implements ColorMapper {
+
+  AnsiColorMapper() throws Throwable {
+    // Calling this constructor could result in a Throwable because JAnsi, which is required to execute code
+    // in this class, might not be present at runtime, thus expected classes are not found.
+  }
+
+  // @formatter:off
+  private final Map<ChatColor, String> MAP = ImmutableMap.<ChatColor, String>builder()
+    .put(ChatColor.BLACK, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLACK).boldOff().toString())
+    .put(ChatColor.DARK_BLUE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLUE).boldOff().toString())
+    .put(ChatColor.DARK_GREEN, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).boldOff().toString())
+    .put(ChatColor.DARK_AQUA, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.CYAN).boldOff().toString())
+    .put(ChatColor.DARK_RED, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.RED).boldOff().toString())
+    .put(ChatColor.DARK_PURPLE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.MAGENTA).boldOff().toString())
+    .put(ChatColor.GOLD, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.YELLOW).boldOff().toString())
+    .put(ChatColor.GRAY, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.WHITE).boldOff().toString())
+    .put(ChatColor.DARK_GRAY, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLACK).bold().toString())
+    .put(ChatColor.BLUE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLUE).bold().toString())
+    .put(ChatColor.GREEN, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).bold().toString())
+    .put(ChatColor.AQUA, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.CYAN).bold().toString())
+    .put(ChatColor.RED, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.RED).bold().toString())
+    .put(ChatColor.LIGHT_PURPLE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.MAGENTA).bold().toString())
+    .put(ChatColor.YELLOW, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.YELLOW).bold().toString())
+    .put(ChatColor.WHITE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.WHITE).bold().toString())
+    .put(ChatColor.MAGIC, Ansi.ansi().a(Attribute.BLINK_SLOW).toString())
+    .put(ChatColor.BOLD, Ansi.ansi().a(Attribute.UNDERLINE_DOUBLE).toString())
+    .put(ChatColor.STRIKETHROUGH, Ansi.ansi().a(Attribute.STRIKETHROUGH_ON).toString())
+    .put(ChatColor.UNDERLINE, Ansi.ansi().a(Attribute.UNDERLINE).toString())
+    .put(ChatColor.ITALIC, Ansi.ansi().a(Attribute.ITALIC).toString())
+    .put(ChatColor.RESET, Ansi.ansi().a(Attribute.RESET).toString())
+  .build();
+  // @formatter:on
+
+  @Override
+  public String map(final String input) {
+    if (input == null) {
+      return "";
+    }
+    String output = input;
+    for (final Map.Entry<ChatColor, String> mapping : MAP.entrySet()) {
+      output = output.replace(mapping.getKey().toString(), mapping.getValue());
+    }
+    return output;
+  }
+
+}

--- a/src/main/java/info/ronjenkins/slf4bukkit/ColorMapper.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/ColorMapper.java
@@ -16,63 +16,21 @@
  */
 package info.ronjenkins.slf4bukkit;
 
-import java.util.Map;
-
 import org.bukkit.ChatColor;
-import org.fusesource.jansi.Ansi;
-import org.fusesource.jansi.Ansi.Attribute;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
- * Utility class that maps {@link ChatColor} values to their JAnsi equivalents,
+ * Utility class that maps {@link ChatColor} values to their equivalents,
  * so that messages logged to the console are formatted correctly.
- *
- * @author Ronald Jack Jenkins Jr.
  */
-public final class ColorMapper {
-
-  // @formatter:off
-  private static final Map<ChatColor, String> MAP = ImmutableMap.<ChatColor, String>builder()
-    .put(ChatColor.BLACK, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLACK).boldOff().toString())
-    .put(ChatColor.DARK_BLUE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLUE).boldOff().toString())
-    .put(ChatColor.DARK_GREEN, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).boldOff().toString())
-    .put(ChatColor.DARK_AQUA, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.CYAN).boldOff().toString())
-    .put(ChatColor.DARK_RED, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.RED).boldOff().toString())
-    .put(ChatColor.DARK_PURPLE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.MAGENTA).boldOff().toString())
-    .put(ChatColor.GOLD, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.YELLOW).boldOff().toString())
-    .put(ChatColor.GRAY, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.WHITE).boldOff().toString())
-    .put(ChatColor.DARK_GRAY, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLACK).bold().toString())
-    .put(ChatColor.BLUE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLUE).bold().toString())
-    .put(ChatColor.GREEN, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).bold().toString())
-    .put(ChatColor.AQUA, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.CYAN).bold().toString())
-    .put(ChatColor.RED, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.RED).bold().toString())
-    .put(ChatColor.LIGHT_PURPLE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.MAGENTA).bold().toString())
-    .put(ChatColor.YELLOW, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.YELLOW).bold().toString())
-    .put(ChatColor.WHITE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.WHITE).bold().toString())
-    .put(ChatColor.MAGIC, Ansi.ansi().a(Attribute.BLINK_SLOW).toString())
-    .put(ChatColor.BOLD, Ansi.ansi().a(Attribute.UNDERLINE_DOUBLE).toString())
-    .put(ChatColor.STRIKETHROUGH, Ansi.ansi().a(Attribute.STRIKETHROUGH_ON).toString())
-    .put(ChatColor.UNDERLINE, Ansi.ansi().a(Attribute.UNDERLINE).toString())
-    .put(ChatColor.ITALIC, Ansi.ansi().a(Attribute.ITALIC).toString())
-    .put(ChatColor.RESET, Ansi.ansi().a(Attribute.RESET).toString())
-  .build();
-  // @formatter:on
+public interface ColorMapper {
 
   /**
-   * Translates {@link ChatColor} directives to their JAnsi equivalents.
+   * Translates {@link ChatColor} directives to their equivalents.
    *
    * @param input
    *          null is coerced to the empty string.
    * @return never null.
    */
-  public static String map(final String input) {
-    if (input == null) { return ""; }
-    String output = input;
-    for (final Map.Entry<ChatColor, String> mapping : ColorMapper.MAP.entrySet()) {
-      output = output.replace(mapping.getKey().toString(), mapping.getValue());
-    }
-    return output;
-  }
+  String map(String input);
 
 }

--- a/src/main/java/info/ronjenkins/slf4bukkit/ColorMapper.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/ColorMapper.java
@@ -16,13 +16,13 @@
  */
 package info.ronjenkins.slf4bukkit;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 
 import org.bukkit.ChatColor;
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.Ansi.Attribute;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 /**
  * Utility class that maps {@link ChatColor} values to their JAnsi equivalents,
@@ -32,8 +32,11 @@ import com.google.common.collect.ImmutableMap;
  */
 public final class ColorMapper {
 
+  private ColorMapper() {
+  }
+
   // @formatter:off
-  private static final Map<ChatColor, String> MAP = ImmutableMap.<ChatColor, String>builder()
+  private final Map<ChatColor, String> MAP = ImmutableMap.<ChatColor, String>builder()
     .put(ChatColor.BLACK, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLACK).boldOff().toString())
     .put(ChatColor.DARK_BLUE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLUE).boldOff().toString())
     .put(ChatColor.DARK_GREEN, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).boldOff().toString())
@@ -60,19 +63,46 @@ public final class ColorMapper {
   // @formatter:on
 
   /**
+   * Attempts to create a new ColorMapper.
+   *
+   * @return a new ColorMapper instance
+   * @throws UnsupportedByBukkitImplementationException if colorMapping is not supported on the BukkitImplementation on
+   *                                                    which this method is called
+   */
+  public static ColorMapper create() throws UnsupportedByBukkitImplementationException {
+    try {
+      return new ColorMapper();
+    } catch (Throwable e) {
+      throw new UnsupportedByBukkitImplementationException(e);
+    }
+
+  }
+
+  /**
    * Translates {@link ChatColor} directives to their JAnsi equivalents.
    *
-   * @param input
-   *          null is coerced to the empty string.
+   * @param input null is coerced to the empty string.
    * @return never null.
    */
-  public static String map(final String input) {
-    if (input == null) { return ""; }
+  public String map(final String input) {
+    if (input == null) {
+      return "";
+    }
     String output = input;
-    for (final Map.Entry<ChatColor, String> mapping : ColorMapper.MAP.entrySet()) {
+    for (final Map.Entry<ChatColor, String> mapping : MAP.entrySet()) {
       output = output.replace(mapping.getKey().toString(), mapping.getValue());
     }
     return output;
+  }
+
+  /**
+   * Thrown when an operation is not supported by the Bukkit implementation the operation runs on.
+   */
+  public static class UnsupportedByBukkitImplementationException extends Exception {
+
+    private UnsupportedByBukkitImplementationException(Throwable e) {
+      super(e);
+    }
   }
 
 }

--- a/src/main/java/info/ronjenkins/slf4bukkit/ColorMapper.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/ColorMapper.java
@@ -16,13 +16,13 @@
  */
 package info.ronjenkins.slf4bukkit;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 import org.bukkit.ChatColor;
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.Ansi.Attribute;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Utility class that maps {@link ChatColor} values to their JAnsi equivalents,
@@ -32,11 +32,8 @@ import java.util.Map;
  */
 public final class ColorMapper {
 
-  private ColorMapper() {
-  }
-
   // @formatter:off
-  private final Map<ChatColor, String> MAP = ImmutableMap.<ChatColor, String>builder()
+  private static final Map<ChatColor, String> MAP = ImmutableMap.<ChatColor, String>builder()
     .put(ChatColor.BLACK, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLACK).boldOff().toString())
     .put(ChatColor.DARK_BLUE, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.BLUE).boldOff().toString())
     .put(ChatColor.DARK_GREEN, Ansi.ansi().a(Attribute.RESET).fg(Ansi.Color.GREEN).boldOff().toString())
@@ -63,46 +60,19 @@ public final class ColorMapper {
   // @formatter:on
 
   /**
-   * Attempts to create a new ColorMapper.
-   *
-   * @return a new ColorMapper instance
-   * @throws UnsupportedByBukkitImplementationException if colorMapping is not supported on the BukkitImplementation on
-   *                                                    which this method is called
-   */
-  public static ColorMapper create() throws UnsupportedByBukkitImplementationException {
-    try {
-      return new ColorMapper();
-    } catch (Throwable e) {
-      throw new UnsupportedByBukkitImplementationException(e);
-    }
-
-  }
-
-  /**
    * Translates {@link ChatColor} directives to their JAnsi equivalents.
    *
-   * @param input null is coerced to the empty string.
+   * @param input
+   *          null is coerced to the empty string.
    * @return never null.
    */
-  public String map(final String input) {
-    if (input == null) {
-      return "";
-    }
+  public static String map(final String input) {
+    if (input == null) { return ""; }
     String output = input;
-    for (final Map.Entry<ChatColor, String> mapping : MAP.entrySet()) {
+    for (final Map.Entry<ChatColor, String> mapping : ColorMapper.MAP.entrySet()) {
       output = output.replace(mapping.getKey().toString(), mapping.getValue());
     }
     return output;
-  }
-
-  /**
-   * Thrown when an operation is not supported by the Bukkit implementation the operation runs on.
-   */
-  public static class UnsupportedByBukkitImplementationException extends Exception {
-
-    private UnsupportedByBukkitImplementationException(Throwable e) {
-      super(e);
-    }
   }
 
 }

--- a/src/main/java/info/ronjenkins/slf4bukkit/ColorMapperFactory.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/ColorMapperFactory.java
@@ -1,0 +1,23 @@
+package info.ronjenkins.slf4bukkit;
+
+/**
+ * Creates {@code ColorMapper} instances.
+ *
+ * @see ColorMapper
+ */
+public final class ColorMapperFactory {
+
+  /**
+   * Creates an new {@code ColorMapper} instance.
+   *
+   * @return a new instance
+   */
+  public static ColorMapper create() {
+    try {
+      return new AnsiColorMapper();
+    } catch (Throwable throwable) {
+      return new NotSupportedColorMapper();
+    }
+  }
+
+}

--- a/src/main/java/info/ronjenkins/slf4bukkit/NotSupportedColorMapper.java
+++ b/src/main/java/info/ronjenkins/slf4bukkit/NotSupportedColorMapper.java
@@ -1,0 +1,12 @@
+package info.ronjenkins.slf4bukkit;
+
+/**
+ * Does not do any mapping but simply returns the given string or, if {@code null} is given, an empty string.
+ */
+final class NotSupportedColorMapper implements ColorMapper {
+
+  @Override
+  public String map(final String input) {
+    return input == null ? "" : input;
+  }
+}

--- a/src/main/java/org/slf4j/impl/BukkitLoggerAdapter.java
+++ b/src/main/java/org/slf4j/impl/BukkitLoggerAdapter.java
@@ -45,6 +45,7 @@
 package org.slf4j.impl;
 
 import info.ronjenkins.slf4bukkit.ColorMapper;
+import info.ronjenkins.slf4bukkit.ColorMapperFactory;
 import info.ronjenkins.slf4bukkit.ColorMarker;
 
 import java.io.IOException;
@@ -218,6 +219,7 @@ public final class BukkitLoggerAdapter implements Logger {
   // The logger name.
   private final String                         name;
   // The short name of this simple log instance
+  private final ColorMapper                    mapper                              = ColorMapperFactory.create();
   private transient String                     shortLogName                        = null;
 
   // NOTE: BukkitPluginLoggerAdapter constructor should have only package access
@@ -1043,6 +1045,6 @@ public final class BukkitLoggerAdapter implements Logger {
 
     // Log the message.
     logger.log(BukkitLoggerAdapter.slf4jLevelIntToBukkitJULLevel(level),
-               ColorMapper.map(buf.toString()));
+               mapper.map(buf.toString()));
   }
 }

--- a/src/main/java/org/slf4j/impl/BukkitLoggerAdapter.java
+++ b/src/main/java/org/slf4j/impl/BukkitLoggerAdapter.java
@@ -44,10 +44,16 @@
  */
 package org.slf4j.impl;
 
-import com.google.common.collect.ImmutableMap;
-
 import info.ronjenkins.slf4bukkit.ColorMapper;
 import info.ronjenkins.slf4bukkit.ColorMarker;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.bukkit.Bukkit;
@@ -61,13 +67,7 @@ import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * <p>
@@ -219,22 +219,11 @@ public final class BukkitLoggerAdapter implements Logger {
   private final String                         name;
   // The short name of this simple log instance
   private transient String                     shortLogName                        = null;
-  private final ThreadLocal<ColorMapper>                    mapper;
 
   // NOTE: BukkitPluginLoggerAdapter constructor should have only package access
   // so that only BukkitPluginLoggerFactory be able to create one.
   BukkitLoggerAdapter(final String name) {
     this.name = name;
-    this.mapper = new ThreadLocal<ColorMapper>() {
-      @Override
-      protected ColorMapper initialValue() {
-        try {
-          return ColorMapper.create();
-        } catch (ColorMapper.UnsupportedByBukkitImplementationException ignore) {
-          return null;
-        }
-      }
-    };
   }
 
   /**
@@ -363,7 +352,7 @@ public final class BukkitLoggerAdapter implements Logger {
    *
    * @param property
    *          the config property where the map exists.
-   * @param defaultValues
+   * @param defaultValue
    *          the fallback values returned by this method.
    * @return never null, always contains one mapping for each {@link Level}, and
    *         contains no null keys/values. Equal to {@code defaultValue} if the
@@ -1054,14 +1043,6 @@ public final class BukkitLoggerAdapter implements Logger {
 
     // Log the message.
     logger.log(BukkitLoggerAdapter.slf4jLevelIntToBukkitJULLevel(level),
-               mapColors(buf.toString()));
-  }
-
-  private String mapColors(String input) {
-    ColorMapper colorMapper = mapper.get();
-    if (colorMapper != null) {
-      return colorMapper.map(input);
-    }
-    return input;
+               ColorMapper.map(buf.toString()));
   }
 }


### PR DESCRIPTION
As explained in #2, `ColorMapper`'s dependency on janis is problematic as not every implementation of Bukkit bundles it. This pull request allows slf4bukkit to work on these platforms while maintaining existing functionality on all platforms that bundle janis:

- `ColorMapper`is changed from a static utility into a simple POJO that is initialized by using a factory method. This method can throw an Exception to indicate that `ColorMapper` cannot be initialized, e.g. because dependencies such as janis are missing.
- `BukkitLoggerAdapter` keeps a thread local reference to `ColorMapper` to allow possible multi-threading. If `ColorMapper`cannot be initialized, it is simply ignored and chat colors are not mapped to any equivalents (normally, if a platform does not bundle janis, it should be able to handle this mapping by itself).
- To make the build work, I also needed to register Spigot's repository in the pom.